### PR TITLE
feat: rewrite following itty-router author help

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,51 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+	  "enabled": true,
+	  "clientKind": "git",
+	  "useIgnoreFile": true,
+	  "defaultBranch": "main"
+	},
+	"linter": {
+	  "rules": {
+		"suspicious": {
+		  "noExplicitAny": "off"
+		},
+		"performance": {
+			"noDelete": "off"
+		},
+		"style": {
+			"noParameterAssign": "off"
+		}
+	  }
+	},
+	"formatter": {
+	  "enabled": true,
+	  "indentStyle": "space",
+	  "indentWidth": 2,
+	  "lineWidth": 100,
+	  "ignore": ["*.min.js", "*.bundle.js"],
+	  "lineEnding": "lf"
+	},
+	"javascript": {
+	  "formatter": {
+		"arrowParentheses": "always",
+		"bracketSameLine": true,
+		"bracketSpacing": true,
+		"jsxQuoteStyle": "double",
+		"quoteProperties": "asNeeded",
+		"quoteStyle": "single",
+		"semicolons": "always",
+		"trailingCommas": "all"
+	  }
+	},
+	"json": {
+	  "formatter": {
+		"trailingCommas": "none"
+	  },
+	  "parser": {
+		"allowComments": true
+	  }
+	}
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,173 @@
 {
   "name": "itty-session",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "itty-session",
-      "version": "0.1.2",
-      "license": "ISC",
+      "version": "0.1.3",
+      "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-session",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Session management middleware for itty-router",
   "main": "src/index.js",
   "type": "module",
@@ -19,5 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "cookie": "^1.0.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-session",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Session management middleware for itty-router",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -1,67 +1,79 @@
 import { parse as parseCookies, serialize as serializeCookies } from 'cookie';
 
-export const createSessionsMiddleware = async (env, db) => {
-  env.__sessions =
-    env.__sessions ||
-    new Map();
+const destroySessionCookie = serializeCookies('session', '', {
+  httpOnly: true,
+  secure: false,
+  path: '/',
+  sameSite: 'strict',
+  maxAge: 0,
+});
 
-  let cookieJar = [];
+const saveSession = async(env, tableName, dbName) => {
+  console.log('Save Session');
+  console.log(this, env, tableName, dbName);
+  const db = env[dbName];
+  await db.prepare(`INSERT INTO ${tableName} (id, data) VALUES (?, ?)`).run(this.id, JSON.stringify(data));
+};
 
-  return {
-    sessionPreflight: async (request) => {
-      const cookies = parseCookies(request.headers.get('Cookie') || '');
-      if (cookies.session) {
-        if (!env.__sessions.has(cookies.session)) {
-          env.__sessions.set(cookies.session, {}); 
-        }
-        request.session = env.__sessions.get(cookies.session);
-      } else {
-        const sessionID = crypto.randomUUID();
-        env.__sessions.set(sessionID, {});
-        request.session = env.__sessions.get(sessionID);
-        cookieJar.push(
-          serializeCookies('session', sessionID, {
-            httpOnly: true,
-            secure: true,
-            path: '/',
-            sameSite: 'strict',
-            maxAge: 60 * 60 * 24 * 365 * 10,
-          })
-        );
+const destroySession = async (cookieJar, env, tableName, dbName) => {
+  console.log('Destroy Session');
+  console.log(data, env, tableName, dbName);
+  const db = env[dbName];
+  await db.prepare(`DELETE FROM ${tableName} WHERE id = ?`).run(data.id);
+  cookieJar.push(destroySessionCookie);
+};
+
+export const createSessionsMiddleware = (dbName = 'SESSIONS', tableName = 'sessions') => ({
+  sessionPreflight: async (request, env, ctx) => {
+    request.cookieJar = [];
+    const cookies = parseCookies(request.headers.get('Cookie') || '');
+    if (cookies.session) {
+      console.log('Got a session cookie: ', cookies.session);
+      const session = await env[dbName].prepare(`SELECT * FROM ${tableName} WHERE id = ?`).first(cookies.session);
+      if (!session) {
+        console.log('No session found in db, deleting cookie');
+        cookieJar.push(destroySessionCookie);
+        return {};
       }
-    },
-
-    destroy: async (request) => {
-      const cookies = parseCookies(request.headers.get('Cookie') || '');
-      env.__sessions.delete(cookies.session);
+      console.log('returning session from db: ', session)
+      session.save = saveSession.bind(session, env, tableName, dbName);
+      session.destroy = destroySession.bind(null, cookieJar, env, tableName, dbName);
+      request.session = session;
+    } else {
+      console.log('No session cookie found, creating a new one');
+      const sessionID = crypto.randomUUID();
+      console.log('New session ID: ', sessionID);
+      await env[dbName].prepare(`INSERT INTO ${tableName} (id, created_at) VALUES (?, ?)`).run(sessionID, new Date());
+      request.session = {};
       cookieJar.push(
-        serializeCookies('session', '', {
+        serializeCookies('session', sessionID, {
           httpOnly: true,
-          secure: false,
+          secure: true,
           path: '/',
           sameSite: 'strict',
-          maxAge: 0,
+          maxAge: 60 * 60 * 24 * 365 * 10,
         })
       );
-    },
+    }
+  },
 
-    sessionify: async (response) => {
-      if (!response) {
-        throw new Error('No fetch handler responded and no upstream to proxy to specified.');
-      }
-      const { headers, status, body } = response;
-      const existingHeaders = Object.fromEntries(headers);
-      const cookies = cookieJar.join('; ');
-      cookieJar = [];
+  sessionify: async (response, request) => {
+    if (!response) {
+      throw new Error('No fetch handler responded and no upstream to proxy to specified.');
+    }
+    await request.session.save();
+    const { headers, status, body } = response;
+    const existingHeaders = Object.fromEntries(headers);
+    const cookies = cookieJar.join('; ');
+    cookieJar = [];
 
-      return new Response(body, {
-        status,
-        headers: {
-          ...existingHeaders,
-          'set-cookie': cookies,
-          'content-type': headers.get('content-type'),
-        },
-      });
-    },
-  };
-};
+    return new Response(body, {
+      status,
+      headers: {
+        ...existingHeaders,
+        'set-cookie': cookies,
+        'content-type': headers.get('content-type'),
+      },
+    });
+  },
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,77 +1,93 @@
 import { parse as parseCookies, serialize as serializeCookies } from 'cookie';
 
-const destroySessionCookie = serializeCookies('session', '', {
-  httpOnly: true,
-  secure: false,
-  path: '/',
-  sameSite: 'strict',
-  maxAge: 0,
-});
+const log = (doLog, level, ...message) => {
+  if(Array.isArray(level)) {
+    message = level;
+    level = 'log';
+  }
+  if(doLog) {
+    console[level](...message);
+  }
+}
 
-const saveSession = async(env, tableName, dbName) => {
-  console.log('Save Session');
-  console.log(this, env, tableName, dbName);
-  const db = env[dbName];
-  await db.prepare(`INSERT INTO ${tableName} (id, data) VALUES (?, ?)`).run(this.id, JSON.stringify(data));
-};
-
-const destroySession = async (cookieJar, env, tableName, dbName) => {
-  console.log('Destroy Session');
-  console.log(data, env, tableName, dbName);
-  const db = env[dbName];
-  await db.prepare(`DELETE FROM ${tableName} WHERE id = ?`).run(data.id);
-  cookieJar.push(destroySessionCookie);
-};
-
-export const createSessionsMiddleware = (dbName = 'SESSIONS', tableName = 'sessions') => ({
-  sessionPreflight: async (request, env, ctx) => {
+export const createSessionsMiddleware = ({
+  dbName = 'SESSIONS',
+  tableName = 'sessions',
+  logging = false,
+} = {}) => ({
+  sessionPreflight: async (request, env) => {
     request.cookieJar = [];
-    const cookies = parseCookies(request.headers.get('Cookie') || '');
-    if (cookies.session) {
-      console.log('Got a session cookie: ', cookies.session);
-      const session = await env[dbName].prepare(`SELECT * FROM ${tableName} WHERE id = ?`).first(cookies.session);
-      if (!session) {
-        console.log('No session found in db, deleting cookie');
-        cookieJar.push(destroySessionCookie);
-        return {};
+    try {
+      const cookies = parseCookies(request.headers.get('Cookie') || '');
+      const sessionData = await env[dbName].prepare(`SELECT * FROM ${tableName} WHERE sid = ?`).bind(cookies?.session).first();
+      log(logging, 'log', `Existing sessionData stored in DB for ${cookies?.session} is: `, JSON.parse(sessionData?.data));
+      request.session = sessionData?.data ? JSON.parse(sessionData?.data) : null;
+      
+      if (!request.session) {
+        const sessionID = crypto.randomUUID();
+        log(logging, 'log', `Creating new session with ID ${sessionID}`);
+        request.session = {};
+        const maxAge = 60 * 60 * 24 * 365 * 10;
+        await env[dbName].prepare(`INSERT INTO ${tableName} (sid, data, expiry) VALUES (?, ?, ?)`).bind(sessionID, JSON.stringify({}), Date.now() + maxAge).run();
+        request.cookieJar.push(
+          serializeCookies('session', sessionID, {
+            httpOnly: true,
+            secure: true,
+            path: '/',
+            sameSite: 'strict',
+            maxAge,
+          })
+        );
       }
-      console.log('returning session from db: ', session)
-      session.save = saveSession.bind(session, env, tableName, dbName);
-      session.destroy = destroySession.bind(null, cookieJar, env, tableName, dbName);
-      request.session = session;
-    } else {
-      console.log('No session cookie found, creating a new one');
-      const sessionID = crypto.randomUUID();
-      console.log('New session ID: ', sessionID);
-      await env[dbName].prepare(`INSERT INTO ${tableName} (id, created_at) VALUES (?, ?)`).run(sessionID, new Date());
-      request.session = {};
-      cookieJar.push(
-        serializeCookies('session', sessionID, {
-          httpOnly: true,
-          secure: true,
-          path: '/',
-          sameSite: 'strict',
-          maxAge: 60 * 60 * 24 * 365 * 10,
-        })
-      );
-    }
-  },
+      
+      request.session.destroy = async () => {
+        const cookies = parseCookies(request.headers.get('Cookie') || '');
+        log(logging, 'log', `Destroying session with ID ${cookies?.session}`);
+        try {
+          await env[dbName].prepare(`DELETE FROM ${tableName} WHERE sid = ?`).bind(cookies?.session).run();
+        } catch (error) {
+          log(logging, 'error', 'Error while destroying session data: ', error);
+        }
 
-  sessionify: async (response, request) => {
+        request.cookieJar.push(
+          serializeCookies('session', '', {
+            httpOnly: true,
+            secure: false,
+            path: '/',
+            sameSite: 'strict',
+            maxAge: 0,
+          })
+        );
+      }
+    } catch(error) {
+      log(logging, 'error', 'Error while creating or reading session data: ', error);
+    }
+    
+  },    
+
+  sessionify: async (response, request, env, ctx) => {
     if (!response) {
       throw new Error('No fetch handler responded and no upstream to proxy to specified.');
     }
-    await request.session.save();
+    const cookies = parseCookies(request.headers.get('Cookie') || '');
+    
     const { headers, status, body } = response;
     const existingHeaders = Object.fromEntries(headers);
-    const cookies = cookieJar.join('; ');
-    cookieJar = [];
+    const responseCookies = request.cookieJar.join('; ');
+    
+    delete request.session.destroy;
+    log(logging, 'log', `Updating session data for session ID ${cookies?.session} with data: `, request.session);
+    try {
+      await env[dbName].prepare(`UPDATE ${tableName} SET data = ? WHERE sid = ?`).bind(JSON.stringify(request.session), cookies?.session).run();
+    } catch (error) {
+      log(logging, 'error', 'Error while updating session data: ', error);
+    }
 
     return new Response(body, {
       status,
       headers: {
         ...existingHeaders,
-        'set-cookie': cookies,
+        'set-cookie': responseCookies,
         'content-type': headers.get('content-type'),
       },
     });


### PR DESCRIPTION
Following advice and code help from @kwhitley , this updates itty-sessions to be run correctly on itty-router v5, resolves an important issue with sessions persisting between requests (big oops), and currently limits session storage to D1 binding only.

Still missing a lot of mechanisms to be a real sessions handler 😓 